### PR TITLE
Fix Declaration of CleanHtmlOutput::get(Illuminate\Database\Eloquent\…

### DIFF
--- a/src/Casts/CleanHtmlOutput.php
+++ b/src/Casts/CleanHtmlOutput.php
@@ -9,7 +9,7 @@ class CleanHtmlOutput implements CastsAttributes
     /**
      * Clean the HTML when casting the given value.
      */
-    public function get(\Illuminate\Database\Eloquent\Model $model, string $key, $value, array $attributes): array
+    public function get($model, string $key, $value, array $attributes)
     {
         return clean($value);
     }
@@ -17,7 +17,7 @@ class CleanHtmlOutput implements CastsAttributes
     /**
      * Prepare the given value for storage. Does not clean the HTML.
      */
-    public function set(\Illuminate\Database\Eloquent\Model $model, string $key, array $value, array $attributes): array
+    public function set($model, string $key, $value, array $attributes)
     {
         return $value;
     }


### PR DESCRIPTION
…Model $model, string $key, $value, array $attributes) must be compatible with

Fix Declaration of CleanHtmlOutput::get(Illuminate\Database\Eloquent\Model $model, string $key, $value, array $attributes) must be compatible with